### PR TITLE
Fix GetTime for GMT users

### DIFF
--- a/pkg/apcssh/cmd_gettime.go
+++ b/pkg/apcssh/cmd_gettime.go
@@ -29,6 +29,7 @@ func (cli *Client) GetTime() (time.Time, error) {
 	timeZoneVal := datePieces[4]
 
 	// GMT time requires + prefix
+	// APC UPS fails to use the required +, so add it
 	if timeZoneVal == "00:00" {
 		timeZoneVal = "+" + timeZoneVal
 	}

--- a/pkg/apcssh/cmd_gettime.go
+++ b/pkg/apcssh/cmd_gettime.go
@@ -28,6 +28,11 @@ func (cli *Client) GetTime() (time.Time, error) {
 	formatUPSVal := datePieces[3]
 	timeZoneVal := datePieces[4]
 
+	// GMT time requires + prefix
+	if timeZoneVal == "00:00" {
+		timeZoneVal = "+" + timeZoneVal
+	}
+
 	// known APC UPS format strings
 	dateFormatVal := ""
 	switch formatUPSVal {


### PR DESCRIPTION
We're fell in to an issue where if the timezone of the APC unit timezone is GMT/UTC, the parsing of the date doesn't work. The fix is to add the `+` prefix which is required by the go parser, when `00:00` is the return timezone.